### PR TITLE
사용자로부터 위치 정보 수신 동의를 받는다.

### DIFF
--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -1,0 +1,5 @@
+import MapPage from "@/src/pages/map"
+
+export default function Map() {
+  return <MapPage />
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,4 @@
-import HomePage from "@/src/pageComponents/home/page"
+import HomePage from "@/src/pages/home"
 
 export default function Home() {
   return <HomePage />

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "react": "^18",
     "react-dom": "^18",
     "react-kakao-maps-sdk": "^1.1.24",
-    "react-query": "^3.39.3"
+    "react-query": "^3.39.3",
+    "zustand": "^4.4.6"
   },
   "devDependencies": {
     "@tailwindcss/line-clamp": "^0.4.4",

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -2,8 +2,12 @@
 
 import Header from "@/src/components/common/Header"
 import IconTileList from "@/src/components/home/IconTileList"
+import { useGeolocationPosition } from "@/src/store/useGeolocationPosition"
+import Link from "next/link"
 
 const HomePage = () => {
+  const init = useGeolocationPosition((state) => state.actions.init)
+
   return (
     <div className="h-[100dvh] w-[100dvw]">
       <Header />
@@ -18,12 +22,15 @@ const HomePage = () => {
           </p>
         </div>
 
-        <button
+        <Link
+          href="/map"
           className="!w-fit rounded-[0.4rem] bg-gray-700 px-[3.8rem] py-[1.6rem] text-[1.6rem] font-bold text-white"
-          onClick={() => {}}
+          onClick={() => {
+            init()
+          }}
         >
           회식 장소 찾기
-        </button>
+        </Link>
       </div>
 
       <div className="relative flex justify-center">

--- a/src/pages/map/index.tsx
+++ b/src/pages/map/index.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import Header from "@/src/components/common/Header"
+import { useGeolocationPosition } from "@/src/store/useGeolocationPosition"
+
+const MapPage = () => {
+  const position = useGeolocationPosition((state) => state.position)
+  const isPositionUpdating = useGeolocationPosition((state) => state.isPositionUpdating)
+
+  return (
+    <div className="flex">
+      <div className="w-[45rem]">
+        <Header />
+      </div>
+
+      <div className="flex-1">
+        {isPositionUpdating ? (
+          <p>Updating Position ....</p>
+        ) : (
+          <>
+            <p>위도 : {position.latitude}</p>
+            <p>경도 : {position.longitude}</p>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default MapPage

--- a/src/store/useGeolocationPosition.ts
+++ b/src/store/useGeolocationPosition.ts
@@ -1,0 +1,78 @@
+import { create } from "zustand"
+
+export interface Position {
+  latitude: number
+  longitude: number
+}
+
+interface IGeolocationPositionState {
+  isPositionUpdating: boolean
+  position: Position
+  coords?: GeolocationCoordinates
+}
+
+interface IGeolocationPositionAction {
+  actions: {
+    setIsPositionUpdating: () => void
+    setPosition: ({ latitude, longitude }: { latitude: number; longitude: number }) => void
+    setCoordinates: (coords: GeolocationCoordinates) => void
+    init: () => void
+  }
+}
+
+type TGeolocationPositionStore = IGeolocationPositionState & IGeolocationPositionAction
+
+export const POSITION_DEFAULT: Position = {
+  latitude: 37.498764,
+  longitude: 127.027492,
+}
+
+const initState: IGeolocationPositionState = {
+  isPositionUpdating: false,
+  position: POSITION_DEFAULT,
+  coords: undefined,
+}
+
+export const useGeolocationPosition = create<TGeolocationPositionStore>((set, get) => ({
+  ...initState,
+
+  actions: {
+    setIsPositionUpdating: () => {
+      set({ isPositionUpdating: true })
+    },
+    setCoordinates: (coords) => {
+      set({
+        coords: coords,
+        position: {
+          latitude: coords.latitude,
+          longitude: coords.longitude,
+        },
+        isPositionUpdating: false,
+      })
+    },
+    setPosition: ({ latitude, longitude }) => {
+      set({
+        position: {
+          latitude: latitude,
+          longitude: longitude,
+        },
+        isPositionUpdating: false,
+      })
+    },
+    init: () => {
+      const geolocationActions = get().actions
+
+      geolocationActions.setIsPositionUpdating()
+
+      navigator.geolocation.getCurrentPosition(
+        (position) => {
+          geolocationActions.setCoordinates(position.coords)
+        },
+        (positionError) => {
+          // TODO : logging user denied Geolocation
+          console.log(positionError)
+        }
+      )
+    },
+  },
+}))

--- a/yarn.lock
+++ b/yarn.lock
@@ -2818,6 +2818,11 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+use-sync-external-store@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
+
 util-deprecate@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
@@ -2907,3 +2912,10 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zustand@^4.4.6:
+  version "4.4.6"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.4.6.tgz#03c78e3e2686c47095c93714c0c600b72a6512bd"
+  integrity sha512-Rb16eW55gqL4W2XZpJh0fnrATxYEG3Apl2gfHTyDSE965x/zxslTikpNch0JgNjJA9zK6gEFW8Fl6d1rTZaqgg==
+  dependencies:
+    use-sync-external-store "1.2.0"


### PR DESCRIPTION
### 문제/이슈/주제: 사용자로부터 위치 정보 수신 동의를 받는다.

### 상세

1. 랜딩 페이지에서 서비스 시작 전 사용자의 위치 정보 수신 동의를 받는다.

- by. Geolocation API
- 좌표 정보를 얻었을 때와 얻지 못했을 때를 고려
    - success : geolocation 의 coordinate 정보를 store 에 셋
    - failed : 초기 타겟 지역인 강남구, 거기서도 강남역 11번 출구의 위치를 기본 좌표 정보로 적용해서 store 에 셋

2. store 에 좌표정보를 셋하는 동안 loading state 를 관리
   
### 미비사항

- 위치 동의를 했으면 세션 스토리지 같은 곳에 사용자가 위치 정보 동의했을 때 얻어낸 좌표값을 영구 저장
    - 서비스 종료 시(브라우저 종료)에 저장하고 있던 값이 제거될 수 있도록 함
    - localStorage 보단 세션 스토리지가 적당할 듯

### Test

- UI

  > - [x] Safari (pc & mobile)
  > - [x] Chrome (pc & mobile)
  > - [x] Firefox (pc & mobile)

- self review
  > - [x] 기획 이해했는지
  > - [x] 기능 이상없는지
  > - [x] 코드 히스토리 알고 있는지
  > - [x] 코드 추가/변경으로 인해 연관된 곳에 영향 없는지
  > - [x] 콩글리쉬
  > - [x] typo
  > - [x] warning message 확인
  > - [x] 무분별한 copy & paste
  > - [ ] 최적화
