### PR TITLE
랜딩페이지 모바일 뷰를 제작한다.

### DIFF
--- a/src/components/home/IconTileList.tsx
+++ b/src/components/home/IconTileList.tsx
@@ -19,14 +19,49 @@ const tileList = [
   ...tileListRepeat1,
 ]
 
+const tabletTileList = [
+  ...tileListRepeat2,
+  ...tileListRepeat2,
+  ...tileListRepeat1,
+  ...tileListRepeat1,
+  ...tileListRepeat2,
+  ...tileListRepeat2,
+]
+
+const mobileTileList = [
+  ...tileListRepeat2,
+  ...tileListRepeat1,
+  ...tileListRepeat1,
+  ...tileListRepeat2,
+  ...tileListRepeat1,
+  ...tileListRepeat2,
+  ...tileListRepeat1,
+]
+
 const IconTileList = () => {
   return (
-    <div className="fixed bottom-0 -z-20 grid grid-cols-8 gap-[3.2rem] max-md:grid-cols-4">
-      <div className="absolute left-0 top-0 h-full w-[100dvw] bg-gradient-to-b from-white via-white via-20% " />
+    <div className="fixed bottom-0 -z-20 grid grid-cols-8 gap-[3.2rem] max-md:grid-cols-6 max-[475px]:grid-cols-4">
+      <div className="absolute left-0 top-0 h-full w-[100dvw] bg-gradient-to-b from-white via-white via-20%" />
 
       {tileList.map((tile, index) => {
         return (
-          <div key={`${tile}_${index}`} className="!w-fit">
+          <div key={`${tile}_${index}`} className="!w-fit max-md:hidden">
+            <Image src={tile} alt="" width={134} height={134} />
+          </div>
+        )
+      })}
+
+      {tabletTileList.map((tile, index) => {
+        return (
+          <div key={`${tile}_${index}`} className="!w-fit max-[475px]:hidden md:hidden">
+            <Image src={tile} alt="" width={134} height={134} />
+          </div>
+        )
+      })}
+
+      {mobileTileList.map((tile, index) => {
+        return (
+          <div key={`${tile}_${index}`} className="!w-fit min-[475px]:hidden">
             <Image src={tile} alt="" width={134} height={134} />
           </div>
         )

--- a/src/components/home/IconTileList.tsx
+++ b/src/components/home/IconTileList.tsx
@@ -21,7 +21,7 @@ const tileList = [
 
 const IconTileList = () => {
   return (
-    <div className="fixed bottom-0 -z-20 grid grid-cols-8 gap-[3.2rem]">
+    <div className="fixed bottom-0 -z-20 grid grid-cols-8 gap-[3.2rem] max-md:grid-cols-4">
       <div className="absolute left-0 top-0 h-full w-[100dvw] bg-gradient-to-b from-white via-white via-20% " />
 
       {tileList.map((tile, index) => {

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -12,13 +12,13 @@ const HomePage = () => {
     <div className="h-[100dvh] w-[100dvw]">
       <Header />
       <div className="flex flex-col items-center">
-        <div className="flex flex-col gap-y-[1.6rem] pb-[3.6rem] pt-[14.5rem]">
-          <h2 className="whitespace-pre-wrap text-center text-[7.2rem] font-bold text-gray-800">
+        <div className="flex flex-col gap-y-[1.6rem] px-[3.2rem] pb-[3.6rem] pt-[14.5rem]">
+          <h2 className="max-md:text-heading-2 max-[475px]:text-heading-3 whitespace-pre-wrap text-center text-[7.2rem] font-bold text-gray-800 max-[475px]:text-[2.8rem]">
             1분만에 맘에 드는{`\n`}회식장소 찾으러가기
           </h2>
 
-          <p className="text-[2rem] font-medium text-gray-600">
-            위치 정보 이용 권한을 허용하시면 내 주변의 다양한 회식 장소를 볼 수 있어요!
+          <p className="max-md:text-heading-3 max-[475px]:text-detail text-center text-[2rem] font-medium text-gray-600 max-[475px]:text-[1.4rem] max-[475px]:font-medium">
+            위치 정보 이용 권한을 허용하고 회식 장소 바로 봐요!
           </p>
         </div>
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -45,8 +45,8 @@ const config: Config = {
       fontSize: {
         "heading-1": ["7.2rem", { lineHeight: "130%", fontWeight: "bold" }],
         "heading-2": ["3.6rem", { lineHeight: "120%", fontWeight: "bold" }],
-        "heading-3": ["2.0rem", { lineHeight: "120%", fontWeight: "medium" }],
-        "heading-4": ["1.8rem", { lineHeight: "120%", fontWeight: "medium" }],
+        "heading-3": ["2.0rem", { lineHeight: "150%", fontWeight: "medium" }],
+        "heading-4": ["1.8rem", { lineHeight: "150%", fontWeight: "medium" }],
         "body-1": ["1.6rem", { lineHeight: "120%", fontWeight: "bold" }],
         "body-2": ["1.6rem", { lineHeight: "120%", fontWeight: "medium" }],
         "body-3": ["1.6rem", { lineHeight: "120%", fontWeight: "normal" }],


### PR DESCRIPTION
### 문제/이슈/주제: 랜딩페이지 모바일 뷰를 제작한다

- #3 

### 상세

| mobile | tablet | pc |
| :---: | :---: | :---: |
| <img width="375" alt="image" src="https://github.com/youngminss/modu-memu-client/assets/50790145/b31af835-9c2b-4436-a285-ed7c600c8c49"> | <img width="375" alt="image" src="https://github.com/youngminss/modu-memu-client/assets/50790145/df2ffbb0-8ef8-4bc6-9be9-06602a754331"> | <img width="375" alt="image" src="https://github.com/youngminss/modu-memu-client/assets/50790145/784031c3-c346-49e1-9442-391037edb1cc"> |

### 시안

https://www.figma.com/file/S0j3Up3jMhnPRAGdwIzmxm/Design?type=design&node-id=784-25394&mode=dev

### 미비사항

- device width 값을 global state 로 관리할 수는 있지만 현 시점에서는 불필요한 리렌더링만 야기할 뿐, 사용해야할 이유가 크지 않기 때문에 적당히 봐줄만한 반응형으로 대응

### Test

- UI

  > - [x] Safari (pc & mobile)
  > - [x] Chrome (pc & mobile)
  > - [x] Firefox (pc & mobile)

- self review
  > - [x] 기획 이해했는지
  > - [x] 기능 이상없는지
  > - [x] 코드 히스토리 알고 있는지
  > - [x] 코드 추가/변경으로 인해 연관된 곳에 영향 없는지
  > - [x] 콩글리쉬
  > - [x] typo
  > - [x] warning message 확인
  > - [x] 무분별한 copy & paste
